### PR TITLE
暗号化時に関数を使用することを検討

### DIFF
--- a/password_manager.sh
+++ b/password_manager.sh
@@ -1,5 +1,23 @@
 #!/bin/bash
 
+#暗号ファイル有の場合、復号する処理
+function d_file() {
+
+    	if [ -f 'pswlog.txt.gpg' ];
+	then
+		# 暗号化ファイルが存在する場合、復号
+		gpg --output 'pswlog.txt' --decrypt 'pswlog.txt.gpg'
+		
+	fi
+}
+
+#暗号化する処理
+function e_file() {
+	# 暗号化ファイルが存在する場合、復号
+	gpg -c 'pswlog.txt'
+}
+
+# メインの処理はここから
 echo 'パスワードマネージャへようこそ！'
 
 while true
@@ -11,7 +29,11 @@ do
        then
 	       echo '1:Add Passwordを選択しました。'
 	       read -p 'サービス名を入力し、enterキーを押してください:' service
-	       if grep -q "^$service:" pswlog.txt 2>/dev/null; # 初回のエラーを非表示
+	       
+	       d_file
+	       
+	       if grep -q "^$service:" pswlog.txt 2>/dev/null;
+	       # 重複登録を拒否する処理。初回のエラーを非表示
 	       then
 		       echo "入力されたサービス: $service は登録済みです。"
 		       echo 'パスワードを取得するには 2 を選択してください。'
@@ -26,8 +48,11 @@ do
        elif [ "$input" = '2' -o "$input" = '２' ];
        then
 	       echo '2:Get Passwordを選択しました。'
+	       
+	       d_file
+	       
 	       read -p 'サービス名を入力し、enterキーを押してください:' service_2
-	       if grep -q "^$service_2:" pswlog.txt; # -qで、標準出力を抑制
+	       if grep -q "^$service_2:" pswlog.txt 2>/dev/null; # -qで、標準出力を抑制し、初回のエラーを非表示
 	       # if grep "^$service_2:" pswlog.txt > /dev/null; # > /dev/nullで、標準出力を抑制
 	       # if a=$(grep "^$service_2:" pswlog.txt); # a=()で、標準出力を抑制
 	         # 上記のif command文は、条件の判定ではなく、シェルコマンドの終了ステータスによる


### PR DESCRIPTION
暗号化、複合用の関数を用意しました。
ステップ2の状態での動作と変わらないですが、暗号化の機能が働いていない様ですので、調査します。
追記：ターミナル上の操作（手入力）では、暗号化、複合できますが、パスフレーズを求められます。シャルスクリプトで動作させる際にこのパスフレーズの要求に対処する必要があるようです。

また、パスワードマネージャを実行すると、暗号化前のファイルが残るので、暗号化がうまく行ったら、削除するようにします。
